### PR TITLE
Fix project root resolution

### DIFF
--- a/install.js
+++ b/install.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const hook = path.join(__dirname, 'hook')
-const root = path.resolve(__dirname, '..', '..')
+const root = path.resolve(__dirname, '..', '..', '..')
 const exists = fs.existsSync || path.existsSync
 
 //

--- a/uninstall.js
+++ b/uninstall.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const exists = fs.existsSync || path.existsSync
-const root = path.resolve(__dirname, '..', '..')
+const root = path.resolve(__dirname, '..', '..', '..')
 let git = path.resolve(root, '.git')
 
 //


### PR DESCRIPTION
The simplistic project root resolution used by the install and uninstall scripts do not account for the `@fastify` scope. This pull request fixes that.