### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
 
 const spawn = require('cross-spawn')
 const which = require('which')
-const path = require('path')
-const util = require('util')
-const tty = require('tty')
+const path = require('node:path')
+const util = require('node:util')
+const tty = require('node:tty')
 
-const fs = require('fs')
+const fs = require('node:fs')
 
 /**
  * Representation of a hook runner.

--- a/install.js
+++ b/install.js
@@ -3,9 +3,9 @@
 //
 // Compatibility with older node.js as path.exists got moved to `fs`.
 //
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
 const hook = path.join(__dirname, 'hook')
 const root = path.resolve(__dirname, '..', '..', '..')
 const exists = fs.existsSync || path.existsSync

--- a/test.js
+++ b/test.js
@@ -147,7 +147,7 @@ t.test('pre-commit', function (t) {
       t.plan(1)
 
       const Hook = proxyquire('.', {
-        fs: {
+        'node:fs': {
           existsSync () {
             return true
           },
@@ -168,7 +168,7 @@ t.test('pre-commit', function (t) {
       t.plan(4)
 
       let Hook = proxyquire('.', {
-        fs: {
+        'node:fs': {
           existsSync () {
             return true
           },
@@ -181,7 +181,7 @@ t.test('pre-commit', function (t) {
       hook = new Hook(exit)
 
       Hook = proxyquire('.', {
-        fs: {
+        'node:fs': {
           existsSync () { return true },
           readFileSync () {
             return Buffer.from('{ "bad": [json }')

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict'
 const t = require('tap')
 const Hook = require('./')
-const tty = require('tty')
+const tty = require('node:tty')
 const ttySupportColor = tty.isatty(process.stdout.fd)
 
 const proxyquire = require('proxyquire')

--- a/uninstall.js
+++ b/uninstall.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const exists = fs.existsSync || path.existsSync
 const root = path.resolve(__dirname, '..', '..', '..')
 let git = path.resolve(root, '.git')


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
