### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "pre-commit": "git+https://git@github.com/fastify/pre-commit.git",
     "proxyquire": "^2.1.3"


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.